### PR TITLE
[Fix] eliminate redundant NormalizeForSearch calls

### DIFF
--- a/TaskbarLyrics.Core/Utilities/LyricMatcher.cs
+++ b/TaskbarLyrics.Core/Utilities/LyricMatcher.cs
@@ -89,9 +89,6 @@ public static class LyricMatcher
 
     private static double GetStringSimilarity(string? s1, string? s2)
     {
-        s1 = NormalizeForSearch(s1);
-        s2 = NormalizeForSearch(s2);
-
         if (string.IsNullOrEmpty(s1) && string.IsNullOrEmpty(s2)) return 1.0;
         if (string.IsNullOrEmpty(s1) || string.IsNullOrEmpty(s2)) return 0.0;
 


### PR DESCRIPTION
LyricMatcher.cs里字符串已经NormalizeForSearch标准化过了一遍，但GetStringSimilarity里又完整跑了一遍。去掉两行重复的NormalizeForSearch调用即可。