### PR TITLE
修复隐藏歌词窗口出现在后台任务窗口中，并添加歌词是否强制置顶的开关

### DIFF
--- a/TaskbarLyrics.App/AppSettings.cs
+++ b/TaskbarLyrics.App/AppSettings.cs
@@ -74,6 +74,8 @@ public sealed class AppSettings
 
     public double YOffset { get; set; }
 
+    public bool ForceAlwaysOnTop { get; set; } = false;
+
     // Debug only: show real-time SMTC timeline diagnostics window.
     public bool EnableSmtcTimelineMonitor { get; set; } = false;
 

--- a/TaskbarLyrics.App/MainWindow.xaml
+++ b/TaskbarLyrics.App/MainWindow.xaml
@@ -11,7 +11,6 @@
         ResizeMode="NoResize"
         ShowInTaskbar="False"
         ShowActivated="False"
-        Topmost="True"
         AllowsTransparency="True"
         UseLayoutRounding="True"
         SnapsToDevicePixels="True"

--- a/TaskbarLyrics.App/MainWindow.xaml.cs
+++ b/TaskbarLyrics.App/MainWindow.xaml.cs
@@ -983,11 +983,17 @@ private void OnSourceInitialized(object? sender, EventArgs e)
         var hwnd = new WindowInteropHelper(this).Handle;
         if (hwnd == IntPtr.Zero)
         {
-            return;
+        return;
         }
+        var settings = (System.Windows.Application.Current as App)?.Settings;
+        var forceTopmost = settings?.ForceAlwaysOnTop == true;
+        Topmost = forceTopmost;
+        var hWndInsertAfter = forceTopmost
+        ? NativeMethods.HWND_TOPMOST
+        : NativeMethods.HWND_TOP;
         NativeMethods.SetWindowPos(
             hwnd,
-            NativeMethods.HWND_TOPMOST,
+            hWndInsertAfter,
             0,
             0,
             0,

--- a/TaskbarLyrics.App/MainWindow.xaml.cs
+++ b/TaskbarLyrics.App/MainWindow.xaml.cs
@@ -195,13 +195,17 @@ public partial class MainWindow : Window
         _spectrumTimer.Start();
     }
 
-    private void OnSourceInitialized(object? sender, EventArgs e)
+private void OnSourceInitialized(object? sender, EventArgs e)
+{
+    if (PresentationSource.FromVisual(this) is HwndSource source)
     {
-        if (PresentationSource.FromVisual(this) is HwndSource source)
-        {
-            source.AddHook(WndProc);
-        }
+        source.AddHook(WndProc);
+
+        var hwnd = source.Handle;
+        var extendedStyle = NativeMethods.GetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE);
+        NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE, (IntPtr)(extendedStyle.ToInt64() | NativeMethods.WS_EX_TOOLWINDOW));
     }
+}
 
     private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
@@ -1054,6 +1058,14 @@ internal static class NativeMethods
     internal const uint SWP_NOOWNERZORDER = 0x0200;
     internal const uint SWP_SHOWWINDOW = 0x0040;
     internal const int SW_SHOWNOACTIVATE = 4;
+    internal const int GWL_EXSTYLE = -20;
+    internal const int WS_EX_TOOLWINDOW = 0x00000080;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 
     [DllImport("user32.dll", SetLastError = true)]
     internal static extern bool SetWindowPos(

--- a/TaskbarLyrics.App/SettingsWindow.xaml.cs
+++ b/TaskbarLyrics.App/SettingsWindow.xaml.cs
@@ -203,6 +203,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
             HorizontalAnchor = _settings.HorizontalAnchor,
             XOffset = _settings.XOffset,
             YOffset = _settings.YOffset,
+            ForceAlwaysOnTop = _settings.ForceAlwaysOnTop,
             EnableSmtcTimelineMonitor = _settings.EnableSmtcTimelineMonitor
         };
     }
@@ -359,6 +360,9 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
                 break;
             case "showTextShadow":
                 _settings.ShowTextShadow = ReadBool(element, _settings.ShowTextShadow);
+                break;
+            case "forceAlwaysOnTop":
+                _settings.ForceAlwaysOnTop = ReadBool(element, _settings.ForceAlwaysOnTop);
                 break;
             case "enableSmtcTimelineMonitor":
                 _settings.EnableSmtcTimelineMonitor = ReadBool(element, _settings.EnableSmtcTimelineMonitor);
@@ -567,6 +571,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         target.HorizontalAnchor = source.HorizontalAnchor;
         target.XOffset = source.XOffset;
         target.YOffset = source.YOffset;
+        target.ForceAlwaysOnTop = source.ForceAlwaysOnTop;
         target.EnableSmtcTimelineMonitor = source.EnableSmtcTimelineMonitor;
     }
 
@@ -759,6 +764,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         public LyricsHorizontalAnchor HorizontalAnchor { get; set; }
         public double XOffset { get; set; }
         public double YOffset { get; set; }
+        public bool ForceAlwaysOnTop { get; set; }
         public bool EnableSmtcTimelineMonitor { get; set; }
     }
 

--- a/TaskbarLyrics.App/Web/Settings/settings.html
+++ b/TaskbarLyrics.App/Web/Settings/settings.html
@@ -78,6 +78,7 @@
             <label class="form-row"><strong>水平锚点</strong><select data-key="horizontalAnchor"><option value="Left">左侧</option><option value="Center">居中</option><option value="Right">右侧</option></select></label>
             <label class="form-row"><strong>X 偏移 (px)</strong><div class="stepper" data-key="xOffset" data-min="-2000" data-max="2000" data-step="10" data-decimals="0"><button data-step="-1">-</button><input data-key="xOffset" inputmode="decimal"><button data-step="1">+</button></div></label>
             <label class="form-row"><strong>Y 偏移 (px)</strong><div class="stepper" data-key="yOffset" data-min="-2000" data-max="2000" data-step="10" data-decimals="0"><button data-step="-1">-</button><input data-key="yOffset" inputmode="decimal"><button data-step="1">+</button></div></label>
+            <label class="row"><span><strong>强制歌词置顶</strong><small>启用后歌词窗口将保持最高优先级，会覆盖在全屏应用之上。关闭时不会遮挡全屏应用。</small></span><input data-key="forceAlwaysOnTop" type="checkbox"></label>
           </div>
         </section>
 


### PR DESCRIPTION
修复了歌词窗口会出现在系统后台任务窗口列表中的问题

歌词窗口没有设置 WS_EX_TOOLWINDOW 扩展样式，导致系统将其视为普通应用窗口出现在后台任务中