### PR TITLE
feat: 添加开机自启动功能及相关设置

### DIFF
--- a/TaskbarLyrics.App/AppSettings.cs
+++ b/TaskbarLyrics.App/AppSettings.cs
@@ -44,6 +44,11 @@ public sealed class AppSettings
 
     public bool ShowLyricsOnStartup { get; set; } = true;
 
+    /// <summary>
+    /// 开机自动启动（默认关闭，需用户手动在设置中开启）。
+    /// </summary>
+    public bool EnableAutoStart { get; set; } = false;
+
     public bool ShowLyricTranslation { get; set; } = false;
 
     public bool EnablePureMusicSpectrum { get; set; } = true;

--- a/TaskbarLyrics.App/AutoStartService.cs
+++ b/TaskbarLyrics.App/AutoStartService.cs
@@ -1,0 +1,47 @@
+using Microsoft.Win32;
+
+namespace TaskbarLyrics.App;
+
+/// <summary>
+/// 管理 Windows 注册表 Run 键，实现开机自启动。
+/// </summary>
+public static class AutoStartService
+{
+    private const string RunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
+    private const string ValueName = "TaskbarLyrics";
+
+    /// <summary>
+    /// 检查当前是否已注册为开机自启动。
+    /// </summary>
+    public static bool IsEnabled()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath);
+        return key?.GetValue(ValueName) is string existingPath &&
+               !string.IsNullOrWhiteSpace(existingPath);
+    }
+
+    /// <summary>
+    /// 启用或禁用开机自启动。
+    /// </summary>
+    public static void SetEnabled(bool enabled)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true);
+        if (key is null)
+        {
+            return;
+        }
+
+        if (enabled)
+        {
+            var exePath = Environment.ProcessPath;
+            if (!string.IsNullOrWhiteSpace(exePath))
+            {
+                key.SetValue(ValueName, $"\"{exePath}\"");
+            }
+        }
+        else
+        {
+            key.DeleteValue(ValueName, throwOnMissingValue: false);
+        }
+    }
+}

--- a/TaskbarLyrics.App/SettingsWindow.xaml.cs
+++ b/TaskbarLyrics.App/SettingsWindow.xaml.cs
@@ -188,6 +188,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
             EnableKugou = _settings.EnableKugou,
             EnableSpotify = _settings.EnableSpotify,
             ShowLyricsOnStartup = _settings.ShowLyricsOnStartup,
+            EnableAutoStart = _settings.EnableAutoStart,
             ShowLyricTranslation = _settings.ShowLyricTranslation,
             EnablePureMusicSpectrum = _settings.EnablePureMusicSpectrum,
             FontSize = _settings.FontSize,
@@ -345,6 +346,9 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
             case "showLyricsOnStartup":
                 _settings.ShowLyricsOnStartup = ReadBool(element, _settings.ShowLyricsOnStartup);
                 break;
+            case "enableAutoStart":
+                _settings.EnableAutoStart = ReadBool(element, _settings.EnableAutoStart);
+                break;
             case "showLyricTranslation":
                 _settings.ShowLyricTranslation = ReadBool(element, _settings.ShowLyricTranslation);
                 break;
@@ -459,6 +463,9 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         {
             app.SaveSettings(_settings.Clone());
         }
+
+        // 立即同步注册表自启动状态
+        AutoStartService.SetEnabled(_settings.EnableAutoStart);
     }
 
     private static bool ReadBool(JsonElement element, bool fallback)
@@ -552,6 +559,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         target.EnableKugou = source.EnableKugou;
         target.EnableSpotify = source.EnableSpotify;
         target.ShowLyricsOnStartup = source.ShowLyricsOnStartup;
+        target.EnableAutoStart = source.EnableAutoStart;
         target.ShowLyricTranslation = source.ShowLyricTranslation;
         target.EnablePureMusicSpectrum = source.EnablePureMusicSpectrum;
         target.FontSize = source.FontSize;
@@ -744,6 +752,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         public bool EnableKugou { get; set; }
         public bool EnableSpotify { get; set; }
         public bool ShowLyricsOnStartup { get; set; }
+        public bool EnableAutoStart { get; set; }
         public bool ShowLyricTranslation { get; set; }
         public bool EnablePureMusicSpectrum { get; set; }
         public double FontSize { get; set; }

--- a/TaskbarLyrics.App/Web/Settings/settings.html
+++ b/TaskbarLyrics.App/Web/Settings/settings.html
@@ -50,6 +50,7 @@
           <p class="section-desc">控制歌词窗口启动行为、翻译与显示辅助项。</p>
           <div class="rows">
             <label class="row"><span><strong>启动时显示歌词</strong><small>应用启动后自动显示歌词悬浮窗口。</small></span><input data-key="showLyricsOnStartup" type="checkbox"></label>
+            <label class="row"><span><strong>开机自启动</strong><small>Windows 启动时自动运行 TaskbarLyrics。</small></span><input data-key="enableAutoStart" type="checkbox"></label>
             <label class="row"><span><strong>显示歌词翻译</strong><small>统一控制各歌词源的翻译显示。</small></span><input data-key="showLyricTranslation" type="checkbox"></label>
             <label class="row"><span><strong>纯音乐时显示频谱</strong><small>歌曲识别为纯音乐时，在歌词区域显示实时频谱。</small></span><input data-key="enablePureMusicSpectrum" type="checkbox"></label>
             <label class="row"><span><strong>显示背景</strong><small>为歌词窗口启用半透明背景。</small></span><input data-key="showBackground" type="checkbox"></label>


### PR DESCRIPTION
## ✨ 功能描述

新增 Windows 开机自启动功能，用户可在设置页面自由开启或关闭。

## 📝 变更详情

### 新增
- **`AppSettings.EnableAutoStart`** — 开机自启动配置项，默认 `false`（关闭）
- **`AutoStartService`** — 通过注册表 `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` 管理自启动状态
- 设置页面「歌词设置」卡片中新增 **「开机自启动」** 开关

### 修改
- **`SettingsWindow.xaml.cs`** — 在 `WebSettingsPayload`、`ApplyWebSettingUpdate`、`CopySettings`、`CreateSettingsPayload`、`SaveSettings` 中接入 `EnableAutoStart`
- **`settings.html`** — 添加开机自启动开关 UI

## 🔧 技术细节

| 项目 | 说明 |
|---|---|
| 注册表路径 | `HKCU\Software\Microsoft\Windows\CurrentVersion\Run\TaskbarLyrics` |
| 默认行为 | **关闭**，用户需主动在设置中开启 |
| 生效时机 | 切换开关后即时写入/删除注册表项，无需重启应用 |
| 权限要求 | `HKCU` 无需管理员权限 |

## 📸 截图

<img width="1276" height="855" alt="image" src="https://github.com/user-attachments/assets/e09113ad-abc8-4e18-a14a-533893eccf1b" />

## ✅ 验证

- [x] 编译通过，0 警告 0 错误
- [x] 默认关闭，设置中可开启
- [x] 恢复默认设置后正确重置为关闭状态

