### PR TITLE
feat : 增加歌词封面显示隐藏的开关控制

### DIFF
--- a/TaskbarLyrics.App/AppSettings.cs
+++ b/TaskbarLyrics.App/AppSettings.cs
@@ -74,6 +74,8 @@ public sealed class AppSettings
 
     public string ForegroundColor { get; set; } = LightForegroundColor;
 
+    public bool ShowCover { get; set; } = true;
+
     public bool ShowBackground { get; set; } = false;
 
     public double BackgroundOpacity { get; set; } = 0.55;

--- a/TaskbarLyrics.App/MainWindow.xaml.cs
+++ b/TaskbarLyrics.App/MainWindow.xaml.cs
@@ -887,7 +887,8 @@ public partial class MainWindow : Window
                 : "none",
             textShadow = settings.ShowTextShadow
                 ? "0 1px 2px rgba(0, 0, 0, 0.36)"
-                : "none"
+                : "none",
+            showCover = settings.ShowCover
         };
 
         var payloadJson = JsonSerializer.Serialize(stylePayload);

--- a/TaskbarLyrics.App/SettingsWindow.xaml.cs
+++ b/TaskbarLyrics.App/SettingsWindow.xaml.cs
@@ -210,6 +210,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
             FontWeight = NormalizeFontWeight(_settings.FontWeight),
             ForegroundColorMode = _settings.ForegroundColorMode,
             ForegroundColor = _settings.ForegroundColor,
+            ShowCover = _settings.ShowCover,
             ShowBackground = _settings.ShowBackground,
             BackgroundOpacity = _settings.BackgroundOpacity,
             ShowBorder = _settings.ShowBorder,
@@ -387,6 +388,9 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
                 break;
             case "showSpectrumWhenLyricsNotFound":
                 _settings.ShowSpectrumWhenLyricsNotFound = ReadBool(element, _settings.ShowSpectrumWhenLyricsNotFound);
+                break;
+            case "showCover":
+                _settings.ShowCover = ReadBool(element, _settings.ShowCover);
                 break;
             case "showBackground":
                 _settings.ShowBackground = ReadBool(element, _settings.ShowBackground);
@@ -705,6 +709,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         target.FontWeight = source.FontWeight;
         target.ForegroundColorMode = source.ForegroundColorMode;
         target.ForegroundColor = source.ForegroundColor;
+        target.ShowCover = source.ShowCover;
         target.ShowBackground = source.ShowBackground;
         target.BackgroundOpacity = source.BackgroundOpacity;
         target.ShowBorder = source.ShowBorder;
@@ -904,6 +909,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         public string FontWeight { get; set; } = "";
         public ForegroundColorMode ForegroundColorMode { get; set; }
         public string ForegroundColor { get; set; } = "";
+        public bool ShowCover { get; set; }
         public bool ShowBackground { get; set; }
         public double BackgroundOpacity { get; set; }
         public bool ShowBorder { get; set; }

--- a/TaskbarLyrics.App/Web/Lyrics/app.js
+++ b/TaskbarLyrics.App/Web/Lyrics/app.js
@@ -861,5 +861,11 @@ window.taskbarLyrics = {
     if (payload.textShadow && CSS.supports("text-shadow", payload.textShadow)) {
       root.style.setProperty("--text-shadow", payload.textShadow);
     }
+
+    if (payload.showCover === false) {
+      document.body.classList.add("hide-cover");
+    } else {
+      document.body.classList.remove("hide-cover");
+    }
   }
 };

--- a/TaskbarLyrics.App/Web/Lyrics/style.css
+++ b/TaskbarLyrics.App/Web/Lyrics/style.css
@@ -110,6 +110,15 @@ html, body {
   opacity: 0.58;
 }
 
+body.hide-cover .shell {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+body.hide-cover .cover,
+body.hide-cover .cover + div {
+  display: none;
+}
+
 .cover-image {
   position: absolute;
   inset: 0;

--- a/TaskbarLyrics.App/Web/Settings/settings.html
+++ b/TaskbarLyrics.App/Web/Settings/settings.html
@@ -58,6 +58,7 @@
             <label class="row"><span><strong>显示频谱</strong><small>启用后，可在特定歌词状态下显示实时音频频谱。</small></span><input data-key="enableSpectrum" type="checkbox"></label>
             <label class="row child-row spectrum-child"><span><strong>纯音乐时显示频谱</strong><small>歌曲识别为纯音乐时，在歌词区域显示实时频谱。</small></span><input data-key="enablePureMusicSpectrum" type="checkbox"></label>
             <label class="row child-row spectrum-child"><span><strong>未检索到歌词时显示频谱</strong><small>歌词源没有返回可用歌词时，用频谱替代“暂未找到歌词”。</small></span><input data-key="showSpectrumWhenLyricsNotFound" type="checkbox"></label>
+            <label class="row"><span><strong>显示歌词封面</strong><small>在歌词窗口左侧显示歌曲封面图片。</small></span><input data-key="showCover" type="checkbox"></label>
             <label class="row"><span><strong>显示背景</strong><small>为歌词窗口启用半透明背景。</small></span><input data-key="showBackground" type="checkbox"></label>
             <label class="row"><span><strong>显示边框</strong><small>为歌词窗口绘制边框，便于深浅背景上分辨。</small></span><input data-key="showBorder" type="checkbox"></label>
           </div>

--- a/TaskbarLyrics.App/Web/Settings/settings.html
+++ b/TaskbarLyrics.App/Web/Settings/settings.html
@@ -58,7 +58,7 @@
             <label class="row"><span><strong>显示频谱</strong><small>启用后，可在特定歌词状态下显示实时音频频谱。</small></span><input data-key="enableSpectrum" type="checkbox"></label>
             <label class="row child-row spectrum-child"><span><strong>纯音乐时显示频谱</strong><small>歌曲识别为纯音乐时，在歌词区域显示实时频谱。</small></span><input data-key="enablePureMusicSpectrum" type="checkbox"></label>
             <label class="row child-row spectrum-child"><span><strong>未检索到歌词时显示频谱</strong><small>歌词源没有返回可用歌词时，用频谱替代“暂未找到歌词”。</small></span><input data-key="showSpectrumWhenLyricsNotFound" type="checkbox"></label>
-            <label class="row"><span><strong>显示歌词封面</strong><small>在歌词窗口左侧显示歌曲封面图片。</small></span><input data-key="showCover" type="checkbox"></label>
+            <label class="row"><span><strong>显示歌曲封面</strong><small>在歌词窗口左侧显示歌曲封面图片。</small></span><input data-key="showCover" type="checkbox"></label>
             <label class="row"><span><strong>显示背景</strong><small>为歌词窗口启用半透明背景。</small></span><input data-key="showBackground" type="checkbox"></label>
             <label class="row"><span><strong>显示边框</strong><small>为歌词窗口绘制边框，便于深浅背景上分辨。</small></span><input data-key="showBorder" type="checkbox"></label>
           </div>


### PR DESCRIPTION
新增歌词封面显示开关，放置在设置窗口「歌词设置」分组内，支持用户自由开启/关闭歌词封面展示，默认开启
<img width="1600" height="1075" alt="image" src="https://github.com/user-attachments/assets/89a44ce9-9946-4b70-8cbc-61276d1c6303" />

<img width="340" height="70" alt="image" src="https://github.com/user-attachments/assets/2b057dc9-9985-4be0-8e3a-acd71f0253e7" />
<img width="340" height="70" alt="image" src="https://github.com/user-attachments/assets/5dc0c2bf-6f17-4038-bdab-058c496a3c16" />

`TaskbarLyrics.App/AppSettings.cs`：新增 ShowCover 配置项，默认开启封面
`TaskbarLyrics.App/SettingsWindow.xaml.cs`：完善设置前后端数据交互逻辑
`TaskbarLyrics.App/MainWindow.xaml.cs`：将封面开关状态传递至歌词页面
`Web/Settings/settings.html`：添加配套 UI 开关
`Web/Lyrics/app.js`：接收配置，动态切换页面封面状态
`Web/Lyrics/style.css`：适配封面隐藏后的窗口布局